### PR TITLE
fix: filename references

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import ReactDOM from 'react-dom';
 import React from 'react';
-import MyApp from './MyApp.jsx';
+import MyApp from './myApp.jsx';
 // is there a better way of doing this?
 import 'ag-grid-root/dist/styles/ag-grid.css';
 import 'ag-grid-root/dist/styles/theme-fresh.css';

--- a/src/myApp.jsx
+++ b/src/myApp.jsx
@@ -4,7 +4,7 @@ import {AgGridReact} from 'ag-grid-react';
 import RefData from './RefData';
 import RowDataFactory from './RowDataFactory';
 import ColDefFactory from './ColDefFactory.jsx';
-import './MyApp.css';
+import './myApp.css';
 
 // take this line out if you do not want to use ag-Grid-Enterprise
 import 'ag-grid-enterprise';


### PR DESCRIPTION
After run on console:

    npm start

This error raised:
```
ERROR in ./src/myApp.jsx
Module not found: Error: Cannot resolve 'file' or 'directory' ./MyApp.css in /var/www/html/ag-grid-example/src
 @ ./src/myApp.jsx 31:0-22
```

The problem was the filenames references, after changed, all worked